### PR TITLE
build(docker): improve dockerfile

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM node:18-alpine as build
+FROM node:18-alpine3.17 as build
 WORKDIR /usr/fsxa-pwa
 
 COPY package*.json ./
@@ -8,14 +8,20 @@ COPY . .
 
 RUN npm run build
 
-FROM node:18-alpine as production
+FROM node:18-alpine3.17 as production
+RUN apk update && apk add dumb-init
+
+ENV NODE_ENV production
+
 WORKDIR /usr/fsxa-pwa
 
-COPY --from=build /usr/fsxa-pwa/.output ./.output
-COPY --from=build /usr/fsxa-pwa/package*.json ./
+COPY --chown=node:node --from=build /usr/fsxa-pwa/.output ./.output
+COPY --chown=node:node  --from=build /usr/fsxa-pwa/package*.json ./
 
 EXPOSE 3000
 
 ENV NODE_ENV=production
 
-CMD ["npm", "run", "start"]
+USER node
+
+CMD ["dumb-init", "node",  "./.output/server/index.mjs"]


### PR DESCRIPTION
- Use fixed node base image version
- Set NODE_ENV
- Use node user
- Use [dumb-init](https://github.com/Yelp/dumb-init)
- Dont use npm run start