### PR TITLE
feat(language image component): adds missing language image component…

### DIFF
--- a/components/PageBodyContent/Section.vue
+++ b/components/PageBodyContent/Section.vue
@@ -32,6 +32,8 @@ const sectionComponent = computed(() => {
       return resolveComponent('SectionProduct')
     case 'teaser':
       return resolveComponent('SectionTeaser')
+    case 'languageimage':
+      return resolveComponent('SectionLanguageImage')
     default:
       return undefined
   }

--- a/components/Section/LanguageImage.vue
+++ b/components/Section/LanguageImage.vue
@@ -1,0 +1,18 @@
+<template>
+  <div>
+    <ElementsImage
+      v-if="data?.st_picture"
+      :data-preview-id="data.st_picture?.previewId"
+      :image="data.st_picture"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Image } from 'fsxa-api'
+interface LanguageImage {
+  st_picture: Image
+}
+
+defineProps<{ data: LanguageImage }>()
+</script>


### PR DESCRIPTION
… on homepage

The component appears to be just an image. The template exists in the PWA project so I wrote the component for it. I'm not sure it's required.