### PR TITLE
fix(post-endpoint): remove attribute mapping from request body

### DIFF
--- a/cypress/e2e/server/api/[endpoint].post.cy.ts
+++ b/cypress/e2e/server/api/[endpoint].post.cy.ts
@@ -65,7 +65,7 @@ describe(`post to /api${FSXAProxyRoutes.FETCH_BY_FILTER_ROUTE}`, () => {
       url: `${baseURL}/api${FSXAProxyRoutes.FETCH_BY_FILTER_ROUTE}`,
       body: {
         locale: 'de_DE',
-        filter: [
+        filters: [
           {
             value: id,
             field: 'identifier',
@@ -86,7 +86,7 @@ describe(`post to /api${FSXAProxyRoutes.FETCH_BY_FILTER_ROUTE}`, () => {
       url: `${baseURL}/api${FSXAProxyRoutes.FETCH_BY_FILTER_ROUTE}`,
       body: {
         locale: 'de_DE',
-        filter: [
+        filters: [
           {
             value: id,
             field: 'identifier',
@@ -106,7 +106,7 @@ describe(`post to /api${FSXAProxyRoutes.FETCH_BY_FILTER_ROUTE}`, () => {
       url: `${baseURL}/api${FSXAProxyRoutes.FETCH_BY_FILTER_ROUTE}`,
       body: {
         locale: 'de_DE',
-        filter: [
+        filters: [
           {
             field: 'identifier',
             operator: ComparisonQueryOperatorEnum.EQUALS

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "fs-tpp-api": "^2.4.7",
-        "fsxa-api": "^10.16.1",
+        "fsxa-api": "^10.16.2",
         "highlight.js": "^11.7.0",
         "reconnecting-websocket": "^4.4.0",
         "ws": "^8.12.1"
@@ -9371,9 +9371,9 @@
       }
     },
     "node_modules/fsxa-api": {
-      "version": "10.16.1",
-      "resolved": "https://registry.npmjs.org/fsxa-api/-/fsxa-api-10.16.1.tgz",
-      "integrity": "sha512-yqeT/2HIh91zSzcpyIeVi6qGfFkGGgB8HnRRjOgzR7LbUmwNjcC+ReqkItphmo9/Bi4wA3SxBcrdmAfeTkfPrg==",
+      "version": "10.16.2",
+      "resolved": "https://registry.npmjs.org/fsxa-api/-/fsxa-api-10.16.2.tgz",
+      "integrity": "sha512-0Fz6Qx3lwWdNiwDK1mQty63EDLpoa1cS6UKOsxk44Pi4rNZibTJ+9bnPTVI1345j3tH9IHBAONcQzCnmXVPOFw==",
       "dependencies": {
         "better-sse": "^0.7.1",
         "body-parser": "^1.19.0",
@@ -28788,9 +28788,9 @@
       "optional": true
     },
     "fsxa-api": {
-      "version": "10.16.1",
-      "resolved": "https://registry.npmjs.org/fsxa-api/-/fsxa-api-10.16.1.tgz",
-      "integrity": "sha512-yqeT/2HIh91zSzcpyIeVi6qGfFkGGgB8HnRRjOgzR7LbUmwNjcC+ReqkItphmo9/Bi4wA3SxBcrdmAfeTkfPrg==",
+      "version": "10.16.2",
+      "resolved": "https://registry.npmjs.org/fsxa-api/-/fsxa-api-10.16.2.tgz",
+      "integrity": "sha512-0Fz6Qx3lwWdNiwDK1mQty63EDLpoa1cS6UKOsxk44Pi4rNZibTJ+9bnPTVI1345j3tH9IHBAONcQzCnmXVPOFw==",
       "requires": {
         "better-sse": "^0.7.1",
         "body-parser": "^1.19.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "dependencies": {
     "fs-tpp-api": "^2.4.7",
-    "fsxa-api": "^10.16.1",
+    "fsxa-api": "^10.16.2",
     "highlight.js": "^11.7.0",
     "reconnecting-websocket": "^4.4.0",
     "ws": "^8.12.1"

--- a/server/api/[endpoint].post.ts
+++ b/server/api/[endpoint].post.ts
@@ -6,10 +6,6 @@ export default defineEventHandler(async (event) => {
   const body = await readBody(event)
   const endpoint = event.context['params']?.['endpoint']
 
-  // TODO: This is because of a mismatch between the FSXA API and the FSXA Proxy API,
-  // should be fixed in a future ticket (TNG-1267)
-  body.filters = body.filter
-
   try {
     switch (`/${endpoint}`) {
       case FSXAProxyRoutes.FETCH_ELEMENT_ROUTE:


### PR DESCRIPTION
There used to be a mapping from the attribute name filter to filters because of a typo in the FSXA-API. This typo has been fixed and the mapping was removed to accommodate for that.